### PR TITLE
Rebuild schema when files change

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ var graphql = require('graphql');
 var schemaBuilderPath = 'server/schema-builder.js'
 var clientSafeOutputPath = 'client/schema.js'
 
-var node = cashaySchema(graphql, schemaBuilderPath, clientSafeOutputPath);
+// Pass a watchNode if you want the schema to be recreated when files change
+var options = { watchNode: myAppTree };
+
+var node = cashaySchema(graphql, schemaBuilderPath, clientSafeOutputPath, options);
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -1,25 +1,41 @@
-var FileCreator = require('broccoli-file-creator');
+var fs = require('fs');
+var path = require('path');
+var Plugin = require('broccoli-plugin');
+var mkdirp = require('mkdirp');
 var RSVP = require('rsvp');
 var { transformSchema } = require('cashay');
 
 module.exports = CashaySchema;
 
-CashaySchema.prototype = Object.create(FileCreator.prototype);
+CashaySchema.prototype = Object.create(Plugin.prototype);
 CashaySchema.prototype.constructor = CashaySchema;
 
-function CashaySchema(graphql, rootSchemaPath, outputFile, _options) {
+function CashaySchema (graphql, rootSchemaPath, outputFile, _options) {
+  var options = _options || {};
+
   if (!(this instanceof CashaySchema)) {
-    return new CashaySchema(graphql, rootSchemaPath, outputFile, _options);
+    return new CashaySchema(graphql, rootSchemaPath, outputFile, options);
   }
 
-  FileCreator.call(this, outputFile, '', _options);
+  // If user supplies a `watchNode` option, we will pass it as `inputNodes`
+  // to the broccoli-plugin base class, which will have the effect of
+  // re-building the cashay client schema whenever the node is changed
+  // e.g. when the user writes changes to a file in their project
+  var inputNodes = options.watchNode ? [options.watchNode] : [];
+
+  Plugin.call(this, inputNodes, {
+    annotation: options.annotation || this.constructor.name + ' ' + outputFile,
+    persistentOutput: true
+  });
 
   this.rootSchemaPath = rootSchemaPath;
   this.filename = outputFile;
   this.graphql = graphql;
 }
 
-CashaySchema.prototype.getContent = function() {
+
+CashaySchema.prototype.build = function() {
+  var outputFilePath = path.join(this.outputPath, this.filename);
   // Allow es2015 syntax in our rootSchema file
   require('babel-register')({
     presets: [require.resolve('babel-preset-es2015')]
@@ -27,10 +43,10 @@ CashaySchema.prototype.getContent = function() {
   // Load the module and build the rootSchema
   var graphql = this.graphql;
   var rootSchema = require(this.rootSchemaPath).default(graphql);
-  return new RSVP.Promise(function(resolve, reject) {
-    // Transform the schema into a client-safe schema
-    transformSchema(rootSchema, graphql.graphql).then(function(schema) {
-      resolve("export default " + JSON.stringify(schema));
-    });
+
+  return transformSchema(rootSchema, graphql.graphql).then(function(schema) {
+    var content = "export default " + JSON.stringify(schema);
+    mkdirp.sync(path.dirname(outputFilePath));
+    fs.writeFileSync(outputFilePath, content, { encoding: 'utf-8' });
   });
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.14.0",
-    "broccoli-file-creator": "github:dustinfarris/broccoli-file-creator#get-content",
+    "broccoli-plugin": "^1.2.2",
     "cashay": "^0.20.7",
     "rsvp": "^3.3.2"
   }


### PR DESCRIPTION
Instead of using broccoli-file-creator, which does not watch for changes
after the initial write, copy+paste the source from file-creator and
modify to add an inputNode option for the purpose of automatic re-writes
whenever a file changes.
