### PR TITLE
Remove babel dependency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,7 +178,7 @@ module.exports = {
         "no-useless-return": "error",
         "no-var": "off",
         "no-void": "error",
-        "no-warning-comments": "error",
+        "no-warning-comments": "warn",
         "no-whitespace-before-property": "error",
         "no-with": "error",
         "object-curly-newline": "off",

--- a/README.md
+++ b/README.md
@@ -50,16 +50,32 @@ path that you specify.
 Note: You must bring your own graphql
 
 ```js
-var cashaySchema = require('broccoli-cashay-schema');
+var cashaySchemaGenerator = require('broccoli-cashay-schema');
 var graphql = require('graphql');
 
-var schemaBuilderPath = 'server/schema-builder.js'
-var clientSafeOutputPath = 'client/schema.js'
+// The plugin will look for a schema.js file in the node you provide
+//   You can override with the option `serverSchemaPath`
+var node = cashaySchemaGenerator(inputNode, {
+  graphql: graphql,
+  clientSchemaPath: 'client/schema.js'
+});
+```
 
-// Pass a watchNode if you want the schema to be recreated when files change
-var options = { watchNode: myAppTree };
 
-var node = cashaySchema(graphql, schemaBuilderPath, clientSafeOutputPath, options);
+## ES6 Syntax
+
+If you are (likely) using ES6 (ECMAScript 2015), you will need to transpile the schema
+file before passing it to broccoli-cashay-schema.
+
+This can be done easily with [broccoli-babel-transpiler](https://github.com/babel/broccoli-babel-transpiler):
+
+```js
+var esTranspiler = require('broccoli-babel-transpiler');
+
+var node = cashaySchema(esTranspiler(inputNode), {
+  graphql: graphql,
+  clientSchemaPath: 'client/schema.js'
+});
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -1,51 +1,62 @@
+require('string.prototype.startswith');
+// TODO: remove this polyfill when cashay addresses
+// https://github.com/mattkrick/cashay/issues/136
+
+var Filter = require('broccoli-filter');
 var fs = require('fs');
-var path = require('path');
-var Plugin = require('broccoli-plugin');
 var mkdirp = require('mkdirp');
+var path = require('path');
 var transformSchema = require('cashay').transformSchema;
 
 module.exports = CashaySchema;
 
-CashaySchema.prototype = Object.create(Plugin.prototype);
-CashaySchema.prototype.constructor = CashaySchema;
+CashaySchema.prototype = Object.create(Filter.prototype);
+CashaySchema.constructor = CashaySchema;
 
-function CashaySchema (graphql, rootSchemaPath, outputFile, _options) {
+function CashaySchema(inputNode, _options) {
   var options = _options || {};
 
   if (!(this instanceof CashaySchema)) {
-    return new CashaySchema(graphql, rootSchemaPath, outputFile, options);
+    return new CashaySchema(inputNode, options);
   }
 
-  // If user supplies a `watchNode` option, we will pass it as `inputNodes`
-  // to the broccoli-plugin base class, which will have the effect of
-  // re-building the cashay client schema whenever the node is changed
-  // e.g. when the user writes changes to a file in their project
-  var inputNodes = options.watchNode ? [options.watchNode] : [];
+  if (!options.graphql) {
+    throw new Error('You must provide the graphql package');
+  }
 
-  Plugin.call(this, inputNodes, {
-    annotation: options.annotation || this.constructor.name + ' ' + outputFile,
-    persistentOutput: true
+  Filter.call(this, inputNode, {
+    annotation: options.annotation
   });
 
-  this.rootSchemaPath = rootSchemaPath;
-  this.filename = outputFile;
-  this.graphql = graphql;
+  // GraphQL package
+  this.graphql = options.graphql;
+  // Server schema path relative to `inputNode`
+  this.serverSchemaPath = options.serverSchemaPath || 'schema.js';
+  // Output path for the client schema (will be appended to plugin output dir)
+  this.clientSchemaPath = options.clientSchemaPath || 'client/schema.js';
 }
 
+CashaySchema.prototype.canProcessFile = function(relativePath) {
+  return relativePath === this.serverSchemaPath;
+}
 
-CashaySchema.prototype.build = function() {
-  var outputFilePath = path.join(this.outputPath, this.filename);
-  // Allow es2015 syntax in our rootSchema file
-  require('babel-register')({
-    presets: [require.resolve('babel-preset-es2015')]
-  });
-  // Load the module and build the rootSchema
-  var graphql = this.graphql;
-  var rootSchema = require(this.rootSchemaPath).default(graphql);
+CashaySchema.prototype.getDestFilePath = function() {
+  return this.clientSchemaPath;
+}
 
-  return transformSchema(rootSchema, graphql.graphql).then(function(schema) {
-    var content = "export default " + JSON.stringify(schema);
-    mkdirp.sync(path.dirname(outputFilePath));
-    fs.writeFileSync(outputFilePath, content, { encoding: 'utf-8' });
-  });
+CashaySchema.prototype.processFile = function(srcDir, destDir, relativePath) {
+
+  var outputPath = path.join(destDir, this.getDestFilePath(relativePath));
+
+  // Load the server schema
+  var fullPath = path.join(srcDir, relativePath);
+  var rootSchema = require(fullPath)(this.graphql);
+
+  // Generate a client-safe schema
+  return transformSchema(rootSchema, this.graphql.graphql).
+    then(function(clientSchema) {
+      var content = 'export default ' + JSON.stringify(clientSchema);
+      mkdirp.sync(path.dirname(outputPath));
+      fs.writeFileSync(outputPath, content, { encoding: 'utf-8' });
+    });
 }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,10 @@
   },
   "homepage": "https://github.com/dustinfarris/broccoli-cashay-schema#readme",
   "dependencies": {
-    "babel-core": "^6.18.0",
-    "babel-preset-es2015": "^6.14.0",
-    "babel-register": "^6.14.0",
-    "broccoli-plugin": "^1.2.2",
+    "broccoli-filter": "^1.2.4",
     "cashay": "^0.22.0",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "string.prototype.startswith": "^0.2.0"
   },
   "devDependencies": {
     "eslint": "^3.10.2"


### PR DESCRIPTION
**BREAKING CHANGE**

Users must provide transpiled input.

This also changes the API to accept arguments as part of options, e.g.:

```js
var esTranspiler = require('broccoli-babel-transpiler');

var node = cashaySchema(esTranspiler(inputNode), {
  graphql: graphql,
  clientSchemaPath: 'graphql/client/schema.js'
});
```